### PR TITLE
Build against latest llvm

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,1 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
 aggregate_check: false
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-17.0.6-stage2

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,5 +2,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
+aggregate_check: false
+
 channels:
   - https://staging.continuum.io/prefect/llvm-17.0.6-stage2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
-staging_channel_upload_target: llvm-17.0.6-stage2
-
 channels:
-  - https://staging.continuum.io/prefect/llvm-17.0.6-stage1-attempt-5
+  - https://staging.continuum.io/prefect/llvm-17.0.6-stage2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
 channels:
   - https://staging.continuum.io/prefect/llvm-17.0.6-stage2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,4 @@
-aggregate_branch: 3.12
+staging_channel_upload_target: llvm-17.0.6-stage2
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-17.0.6-stage1-attempt-5

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -51,6 +51,12 @@ done
 # - `sparse_conv_3d.mlir` crashes during JIT execution on some platforms
 TEST_SKIPS="correctness.mlir|dense_output_bf16.mlir|sparse_.*.mlir"
 
+# Skip pdll-lsp-server tests on Linux platforms
+if [[ "${target_platform}" == linux-* ]]; then
+    # Add pdll-lsp-server tests to the skip list
+    TEST_SKIPS="${TEST_SKIPS}|mlir-pdll-lsp-server/.*\.test"
+fi
+
 # Run tests manually and skip known failures
 cd ${SRC_DIR}/build/test
 ${PYTHON} ${BUILD_PREFIX}/bin/llvm-lit -sv --filter-out="${TEST_SKIPS}" .

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,3 +6,8 @@ c_compiler:            # [win]
 - vs2019               # [win]
 cxx_compiler:          # [win]
 - vs2019               # [win]
+
+c_compiler_version:
+  - 17.0.6            # [osx]
+cxx_compiler_version:
+  - 17.0.6            # [osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,9 +3,9 @@ c_compiler:         # [osx]
 cxx_compiler:       # [osx]
   - clang_bootstrap # [osx]
 c_compiler:            # [win]
-- vs2019               # [win]
+  - vs2022             # [win]
 cxx_compiler:          # [win]
-- vs2019               # [win]
+  - vs2022             # [win]
 
 c_compiler_version:
   - 17.0.6            # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - 0001-Support-cross-compiling-standalone-MLIR.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -25,7 +25,6 @@ requirements:
     # both of these required to run testing
     - lit     {{ version }}
     - llvmdev {{ version }}
-    - python
   host:
     - llvmdev {{ version }}
     - llvm {{ version }}
@@ -38,8 +37,6 @@ outputs:
     script: install_mlir.sh  # [unix]
     script: install_mlir.bat  # [win]
     build:
-      missing_dso_whitelist:  # [linux and s390x]
-        - $RPATH/ld64.so.1    # [linux and s390x]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -75,8 +72,6 @@ outputs:
       run_exports:
         - {{ pin_subpackage("libmlir" ~ major_version, max_pin="x.x") }}   # [unix]
       skip: true  # [win]
-      missing_dso_whitelist:  # [s390x]
-        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -95,12 +90,12 @@ outputs:
         - test -f "$PREFIX/lib/libmlir_runner_utils.so.{{ major_version }}"        # [linux]
         - test -f "$PREFIX/lib/libmlir_c_runner_utils.so.{{ major_version }}"      # [linux]
         - test -f "$PREFIX/lib/libmlir_async_runtime.so.{{ major_version }}"       # [linux]
-        - test -f "$PREFIX/lib/libmlir_float16_utils.so.{{ major_version }}"        # [linux]
+        - test -f "$PREFIX/lib/libmlir_float16_utils.so.{{ major_version }}"       # [linux]
         - test -f "$PREFIX/lib/libMLIR.{{ major_version }}.dylib"                  # [osx]
         - test -f "$PREFIX/lib/libmlir_runner_utils.{{ major_version }}.dylib"     # [osx]
         - test -f "$PREFIX/lib/libmlir_c_runner_utils.{{ major_version }}.dylib"   # [osx]
         - test -f "$PREFIX/lib/libmlir_async_runtime.{{ major_version }}.dylib"    # [osx]
-        - test -f "$PREFIX/lib/libmlir_float16_utils.{{ major_version }}.dylib"     # [osx]
+        - test -f "$PREFIX/lib/libmlir_float16_utils.{{ major_version }}.dylib"    # [osx]
 
         # absence of unversioned libraries
         - test ! -f "$PREFIX/lib/libMLIR$SHLIB_EXT"                   # [unix]
@@ -108,7 +103,7 @@ outputs:
         - test ! -f "$PREFIX/lib/libmlir_c_runner_utils$SHLIB_EXT"    # [unix]
         - test ! -f "$PREFIX/lib/libmlir_c_runner_utils_static.a"     # [unix]
         - test ! -f "$PREFIX/lib/libmlir_async_runtime$SHLIB_EXT"     # [unix]
-        - test ! -f "$PREFIX/lib/libmlir_float16_utils$SHLIB_EXT"      # [unix]
+        - test ! -f "$PREFIX/lib/libmlir_float16_utils$SHLIB_EXT"     # [unix]
 
   - name: libmlir
     script: install_libmlir.sh   # [unix]
@@ -116,8 +111,6 @@ outputs:
     build:
       run_exports:   # [unix]
         - {{ pin_subpackage("libmlir" ~ major_version, max_pin="x.x") }}   # [unix]
-      missing_dso_whitelist:  # [s390x]
-        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
mlir rebuild

[PKG-3917](https://anaconda.atlassian.net/browse/PKG-3917)

## Changes
- Explicitly skip problematic tests over an `|| true`
- Build with LLVM 17
- Minor recipe cleanup

[PKG-3917]: https://anaconda.atlassian.net/browse/PKG-3917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ